### PR TITLE
Use the `@PhpCsFixer` preset

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -31,6 +31,7 @@ class Factory
         'dir_constant'                               => true,
         'ereg_to_preg'                               => true,
         'error_suppression'                          => true,
+        'escape_implicit_backslashes'                => false, // Too many changes for now
         'function_to_constant'                       => true,
         'general_phpdoc_annotation_remove'           => ['annotations' => []],
         'heredoc_indentation'                        => false, // Too many changes for now
@@ -42,11 +43,16 @@ class Factory
         'method_argument_space'                      => ['on_multiline' => 'ignore'],
         'mb_str_functions'                           => true,
         'modernize_types_casting'                    => true,
+        'multiline_whitespace_before_semicolons'     => ['strategy' => 'no_multi_line'], // Supposedly the default, but doesn't behave as such?
         'new_with_braces'                            => false, // We prefer the opposite to @PhpCsFixer
         'no_alias_functions'                         => true,
+        'no_blank_lines_after_phpdoc'                => false, // Too many changes for now
         'no_blank_lines_before_namespace'            => true,
         'no_break_comment'                           => false, // We prefer the opposite to @PSR2 and @PhpCsFixer
+        'no_extra_blank_lines'                       => false, // Too many changes for now
         'no_homoglyph_names'                         => true,
+        'no_multiline_whitespace_around_double_arrow'=> false, // Too many changes for now
+        'no_null_property_initialization'            => false, // Too many changes for now
         'no_php4_constructor'                        => true,
         'no_short_echo_tag'                          => false, // We prefer the opposite to @PhpCsFixer
         'no_unneeded_control_parentheses'            => [ // We occasionally use around `return`
@@ -92,6 +98,7 @@ class Factory
         'phpdoc_no_alias_tag'                        => false, // Later, avoiding changes for now
         'phpdoc_order'                               => false, // Later, avoiding changes for now
         'phpdoc_return_self_reference'               => false, // Later, avoiding changes for now
+        'phpdoc_separation'                          => false, // Later, avoiding changes for now
         'phpdoc_summary'                             => false, // Later, avoiding changes for now
         'phpdoc_to_comment'                          => false, // Later, avoiding changes for now
         'phpdoc_trim'                                => false, // Later, avoiding changes for now
@@ -103,6 +110,8 @@ class Factory
         'simplified_null_return'                     => true,
         'single_blank_line_before_namespace'         => false, // We prefer no_blank_lines_before_namespace
         'single_import_per_statement'                => false, // We like import grouping within the same namespace
+        'single_quote'                               => false, // Later, avoiding changes for now
+        'single_trait_insert_per_statement'          => false, // We like grouping traits in one statement
         'strict_comparison'                          => true,
         'ternary_to_null_coalescing'                 => true,
         'void_return'                                => true,

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -15,8 +15,7 @@ class Factory
     // @todo: Adopt the '@PhpCsFixer' preset (as the second rule), then remove inherited rules unless we differ
     public const DEFAULT_RULES = [
         '@PSR2'                                      => true,
-        'align_multiline_comment'                    => true,
-        'array_indentation'                          => true,
+        '@PhpCsFixer'                                => true,
         'array_syntax'                               => ['syntax' => 'short'],
         'backtick_to_shell_exec'                     => true,
         'binary_operator_spaces'                     => ['default' => 'align_single_space'],
@@ -24,82 +23,39 @@ class Factory
         'blank_line_before_statement'                => [
             'statements' => ['case', 'for', 'foreach', 'if', 'return', 'switch', 'try', 'while'],
         ],
-        'cast_spaces'                                => ['space' => 'single'],
         'class_attributes_separation'                => ['elements' => ['method']], // We like to group const/property
         'class_keyword_remove'                       => false, // We like IDEs picking up usage via ::class
-        'combine_consecutive_issets'                 => true,
-        'combine_consecutive_unsets'                 => true,
         'combine_nested_dirname'                     => true,
-        'compact_nullable_typehint'                  => true,
         'concat_space'                               => ['spacing' => 'one'],
         'date_time_immutable'                        => true,
-        'declare_equal_normalize'                    => true,
         'declare_strict_types'                       => false,
         'dir_constant'                               => true,
         'ereg_to_preg'                               => true,
         'error_suppression'                          => true,
-        'explicit_indirect_variable'                 => true,
-        'explicit_string_variable'                   => true,
-        'fully_qualified_strict_types'               => true,
         'function_to_constant'                       => true,
-        'function_typehint_space'                    => true,
         'general_phpdoc_annotation_remove'           => ['annotations' => []],
         'heredoc_indentation'                        => false, // Too many changes for now
         'heredoc_to_nowdoc'                          => false, // Too many changes for now
         'implode_call'                               => true,
-        'include'                                    => true,
+        'increment_style'                            => false, // Ignore forcing by @PhpCsFixer
         'linebreak_after_opening_tag'                => true,
         'logical_operators'                          => true,
-        'lowercase_cast'                             => true,
-        'lowercase_static_reference'                 => true,
-        'magic_constant_casing'                      => true,
-        'magic_method_casing'                        => true,
         'method_argument_space'                      => ['on_multiline' => 'ignore'],
-        'method_chaining_indentation'                => true,
         'mb_str_functions'                           => true,
         'modernize_types_casting'                    => true,
-        'multiline_comment_opening_closing'          => true,
-        'multiline_whitespace_before_semicolons'     => true,
-        'native_function_casing'                     => true,
         'new_with_braces'                            => false, // We prefer the opposite to @PhpCsFixer
         'no_alias_functions'                         => true,
-        'no_alternative_syntax'                      => true,
-        'no_binary_string'                           => true,
-        'no_blank_lines_after_class_opening'         => true,
         'no_blank_lines_before_namespace'            => true,
         'no_break_comment'                           => false, // We prefer the opposite to @PSR2 and @PhpCsFixer
-        'no_empty_comment'                           => true,
-        'no_empty_phpdoc'                            => true,
-        'no_empty_statement'                         => true,
-        'no_extra_blank_lines'                       => ['tokens' => ['extra']],
         'no_homoglyph_names'                         => true,
-        'no_leading_import_slash'                    => true,
-        'no_leading_namespace_whitespace'            => true,
-        'no_mixed_echo_print'                        => ['use' => 'echo'],
         'no_php4_constructor'                        => true,
-        'no_short_bool_cast'                         => true,
         'no_short_echo_tag'                          => false, // We prefer the opposite to @PhpCsFixer
-        'no_singleline_whitespace_before_semicolons' => true,
-        'no_spaces_around_offset'                    => true,
-        'no_superfluous_elseif'                      => true,
-        'no_superfluous_phpdoc_tags'                 => true,
-        'no_trailing_comma_in_list_call'             => true,
-        'no_trailing_comma_in_singleline_array'      => true,
         'no_unneeded_control_parentheses'            => [ // We occasionally use around `return`
             'statements' => ['break', 'clone', 'continue', 'echo_print', 'switch_case', 'yield'],
         ],
-        'no_unneeded_curly_braces'                   => true,
-        'no_unset_cast'                              => true,
         'no_unreachable_default_argument_value'      => true,
-        'no_unused_imports'                          => true,
-        'no_useless_else'                            => true,
-        'no_useless_return'                          => true,
-        'no_whitespace_before_comma_in_array'        => true,
-        'no_whitespace_in_blank_line'                => true,
         'non_printable_character'                    => false, // We have these in tests
-        'normalize_index_brace'                      => true,
         'not_operator_with_successor_space'          => true,
-        'object_operator_without_whitespace'         => true,
         'ordered_class_elements'                     => [ // Default, except we don't order methods for now
             'use_trait',
             'constant_public',
@@ -121,36 +77,38 @@ class Factory
         'php_unit_dedicate_assert'                   => true,
         'php_unit_dedicate_assert_internal_type'     => true,
         'php_unit_expectation'                       => true,
+        'php_unit_internal_class'                    => false, // We prefer the opposite to @PhpCsFixer
         'php_unit_method_casing'                     => ['case' => 'snake_case'],
         'php_unit_namespaced'                        => true,
         'php_unit_no_expectation_annotation'         => true,
         'php_unit_set_up_tear_down_visibility'       => true,
         'php_unit_strict'                            => true,
         'php_unit_test_annotation'                   => true,
+        'php_unit_test_class_requires_covers'        => false, // We prefer the opposite to @PhpCsFixer
+        'phpdoc_add_missing_param_annotation'        => false, // Later, avoiding changes for now
+        'phpdoc_align'                               => false, // Later, avoiding changes for now
+        'phpdoc_annotation_without_dot'              => false, // Later, avoiding changes for now
+        'phpdoc_indent'                              => false, // Later, avoiding changes for now
+        'phpdoc_inline_tag'                          => false, // Later, avoiding changes for now
+        'phpdoc_no_alias_tag'                        => false, // Later, avoiding changes for now
+        'phpdoc_order'                               => false, // Later, avoiding changes for now
+        'phpdoc_return_self_reference'               => false, // Later, avoiding changes for now
+        'phpdoc_summary'                             => false, // Later, avoiding changes for now
+        'phpdoc_to_comment'                          => false, // Later, avoiding changes for now
+        'phpdoc_trim'                                => false, // Later, avoiding changes for now
+        'phpdoc_trim'                                => false, // Later, avoiding changes for now
+        'phpdoc_trim'                                => false, // Later, avoiding changes for now
+        'protected_to_private'                       => false,
         'psr4'                                       => true,
         'random_api_migration'                       => true,
-        'return_assignment'                          => true,
-        'return_type_declaration'                    => true,
         'self_accessor'                              => true,
-        'semicolon_after_instruction'                => true,
         'set_type_to_cast'                           => true,
-        'short_scalar_cast'                          => true,
-        'simple_to_complex_string_variable'          => true,
         'simplified_null_return'                     => true,
         'single_blank_line_before_namespace'         => false, // We prefer no_blank_lines_before_namespace
         'single_import_per_statement'                => false, // We like import grouping within the same namespace
-        'single_line_comment_style'                  => true,
-        'space_after_semicolon'                      => true,
-        'standardize_increment'                      => true,
-        'standardize_not_equals'                     => true,
         'strict_comparison'                          => true,
-        'ternary_operator_spaces'                    => true,
         'ternary_to_null_coalescing'                 => true,
-        'trailing_comma_in_multiline_array'          => true,
-        'trim_array_spaces'                          => true,
-        'unary_operator_spaces'                      => true,
         'void_return'                                => true,
-        'whitespace_after_comma_in_array'            => true,
         'yoda_style'                                 => false, // We prefer the opposite to @PhpCsFixer
     ];
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,7 +37,7 @@ class Factory
         'heredoc_indentation'                        => false, // Too many changes for now
         'heredoc_to_nowdoc'                          => false, // Too many changes for now
         'implode_call'                               => true,
-        'increment_style'                            => false, // Ignore forcing by @PhpCsFixer
+        'increment_style'                            => false, // Sometimes either is appropriate
         'linebreak_after_opening_tag'                => true,
         'logical_operators'                          => true,
         'method_argument_space'                      => ['on_multiline' => 'ignore'],

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,7 +12,6 @@ class Factory
     public const DEFAULT_EXCLUDED_NAME = 'AcceptanceTesterActions.php'; // Annotated with @codingStandardsIgnoreFile
 
     // @todo: Use https://mlocati.github.io/php-cs-fixer-configurator/#version:2.15|configurator and find gaps to plug
-    // @todo: Adopt the '@PhpCsFixer' preset (as the second rule), then remove inherited rules unless we differ
     public const DEFAULT_RULES = [
         '@PSR2'                                      => true,
         '@PhpCsFixer'                                => true,
@@ -95,8 +94,6 @@ class Factory
         'phpdoc_return_self_reference'               => false, // Later, avoiding changes for now
         'phpdoc_summary'                             => false, // Later, avoiding changes for now
         'phpdoc_to_comment'                          => false, // Later, avoiding changes for now
-        'phpdoc_trim'                                => false, // Later, avoiding changes for now
-        'phpdoc_trim'                                => false, // Later, avoiding changes for now
         'phpdoc_trim'                                => false, // Later, avoiding changes for now
         'protected_to_private'                       => false,
         'psr4'                                       => true,


### PR DESCRIPTION
- Include the `@PhpCsFixer` preset, because we're close enough now
- Remove 61 rules that are included in the `@PhpCsFixer` preset
- Add 24 (temporary) rules to disable some of the rules that the `@PhpCsFixer` preset introduces (until we're ready to adopt them, and deal with the resulting code changes)

This has been tested to be a backward compatible change, i.e. the new rules make zero changes to our largest codebase.